### PR TITLE
Correct formula leap year

### DIFF
--- a/index.js
+++ b/index.js
@@ -292,7 +292,7 @@ function updateAvailableDays() {
     var day = parseInt($('.js-select-day').val());
     var month = parseInt($('.js-select-month').val());
     var year = parseInt($('.js-select-year').val());
-    var leap = year % 4 === 0;
+    var leap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
     $('.js-day').prop('disabled', false);
     switch (month) {
         case 1:

--- a/index.ts
+++ b/index.ts
@@ -330,7 +330,7 @@ function updateAvailableDays(): void {
   var day   = parseInt($('.js-select-day').val())
   var month = parseInt($('.js-select-month').val())
   var year  = parseInt($('.js-select-year').val())
-  var leap  = year % 4 === 0
+  var leap  = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0
 
   $('.js-day').prop('disabled', false)
 


### PR DESCRIPTION
The formula for determining is a year is a leap year is not:

``` javascript
var leap = year % 4 === 0;
```

but

``` javascript
var leap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
```

(This is my first pull request, I hope I've done everything alright)
